### PR TITLE
Show build errors

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ var APP_DIR = path.resolve(__dirname, 'webroot/src/');
 
 var config = {
     entry: APP_DIR + '/index.js',
+    bail: true,
     output: {
         path: BUILD_DIR,
         filename: 'bundle.js'


### PR DESCRIPTION
Webpack was just swallowing build/compilation errors which made it non-obvious when things like syntax errors were happening.